### PR TITLE
Agent Answer Performance by Group with entity selector and adapted to ACLs

### DIFF
--- a/src/Admin/ACL/Entries.vue
+++ b/src/Admin/ACL/Entries.vue
@@ -4,7 +4,7 @@
   <b-row><b-col><h3>Queues:</h3></b-col></b-row>
   <b-row><b-col><queues v-model="queues" @add="set('queue', $event)" @remove="unset('queue', $event)"></queues></b-col></b-row>
 
-  <b-row style="margin-top: 20px"><b-col><h3>Queue Group:</h3></b-col></b-row>
+  <b-row style="margin-top: 20px"><b-col><h3>Queue Groups:</h3></b-col></b-row>
   <b-row><b-col><queue-groups v-model="queue_groups" @add="set('queue_group', $event)" @remove="unset('queue_group', $event)"></queue-groups></b-col></b-row>
 
   <b-row style="margin-top: 20px"><b-col><h3>Clients:</h3></b-col></b-row>
@@ -13,7 +13,7 @@
   <b-row style="margin-top: 20px"><b-col><h3>Agents:</h3></b-col></b-row>
   <b-row><b-col><agents v-model="agents" @add="set('agent', $event)" @remove="unset('agent', $event)"></agents></b-col></b-row>
 
-  <b-row style="margin-top: 20px"><b-col><h3>Agent Group:</h3></b-col></b-row>
+  <b-row style="margin-top: 20px"><b-col><h3>Agent Groups:</h3></b-col></b-row>
   <b-row><b-col><agent-groups v-model="agent_groups" @add="set('agent_group', $event)" @remove="unset('agent_group', $event)"></agent-groups></b-col></b-row>
 
   <b-row style="margin-top: 20px"><b-col><h3>Lines In:</h3></b-col></b-row>

--- a/src/Report/Legacy/Agent/AgentActivityByGroup.vue
+++ b/src/Report/Legacy/Agent/AgentActivityByGroup.vue
@@ -1,15 +1,205 @@
 <template>
-  <div style="margin-top: 20px">
-    <strong>{{ title }}</strong> - To be added</div>
+  <report v-bind="reportFields" v-on:apply="query" v-on:reset="reset">
+    <div slot="input-controls">
+      <from-to v-model="fromTo"></from-to>
+      <entity-selector v-model="agentGroups" :query=agentGroupsQuery entity="Agent Groups"></entity-selector>
+    </div>
+    <div slot="report">
+      <table>
+        <tr>
+          <td class='table-sm table-header-group' style="width: 187px; max-width: 187px; min-width: 187px">
+            Agent
+          </td>
+          <td class='table-sm table-header-group' style="width: 319px; max-width: 319px; min-width: 319px">
+            Inbound Activity
+          </td>
+          <td class='table-sm table-header-group' style="width: 256px; max-width: 256px; min-width: 256px">
+            Outbound Activity
+          </td>
+          <td class='table-sm table-header-group' style="width: 128px; max-width: 128px; min-width: 128px">
+            Total Activity
+          </td>
+        </tr>
+      </table>
+      <b-table style="min-width: 6px; max-width: 6px; table-layout: fixed" small hover :items="sessions" :fields="fields">
+      </b-table>
+    </div>
+  </report>
 </template>
 
 <script>
+import Report from '@/Report/Legacy/Report'
+import FromTo from '@/Report/Input/FromTo'
+import EntitySelector from '@/Report/Input/EntitySelector'
+import Moment from 'moment'
+
 export default {
   name: 'AgentActivityByGroup',
+  components: {
+    'report': Report,
+    'from-to': FromTo,
+    'entity-selector': EntitySelector
+  },
   data () {
     return {
-      title: "Agent Activity by Group"
+      fields: {
+        id: {
+          label: 'Name',
+          tdClass: 'table-body-blue',
+          thClass: 'table-header',
+          thStyle: { width: '120px' },
+          sortable: true,
+          formatter: v => this.findName(v)
+        },
+        login: {
+          label: 'Login',
+          tdClass: 'table-body-blue-last-in-group',
+          thClass: 'table-header-last-in-group',
+          thStyle: { width: '67px' },
+          formatter: (_v, _, item) => this.findLogin(item.id)
+        },
+        in_answered: {
+          label: 'Total Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        in_talk_time: {
+          label: 'Total Time',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? this.durationFormatter(v) : this.durationFormatter(0)
+        },
+        in_completed: {
+          label: 'Completed Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        in_transferred: {
+          label: 'Transferred Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        in_avg_hold_time: {
+          label: 'Avg. Hold Time',
+          tdClass: ['table-body-green-last-in-group', 'text-align-right'],
+          thClass: 'table-header-last-in-group',
+          thStyle: { width: '67px' },
+          formatter: (v, _, item) => v ? this.durationFormatter(v) : 'NA'
+        },
+        out_started: {
+          label: 'Started Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        out_placed: {
+          label: 'Sent Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        out_answered: {
+          label: 'Answered Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        out_talk_time: {
+          label: 'Total Time',
+          tdClass: ['table-body-green-last-in-group', 'text-align-right'],
+          thClass: 'table-header-last-in-group',
+          thStyle: { width: '67px' },
+          formatter: v => v ? this.durationFormatter(v) : this.durationFormatter(0)
+        },
+        total_calls: {
+          label: 'Total Calls',
+          tdClass: ['table-body-orange', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        total_talk_time: {
+          label: 'Total Time',
+          tdClass: ['table-body-orange', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? this.durationFormatter(v) : this.durationFormatter(0)
+        }
+      },
+      fromTo: {
+        date_start: Moment().subtract(1, 'days').format(),
+        date_end: Moment().format(),
+      },
+      agentGroups: [],
+      agents: [],
+      reportFields: {
+        name: 'Agent Activity by Group',
+        title: 'Agent Activity by Group',
+        from: undefined,
+        to: undefined
+      },
+      sessions: [],
+      agentGroupsQuery: function () {
+        return this.$agent.p_mfa('ws_agent', 'agent_groups')
+      }
     }
+  },
+  methods: {
+    query: async function () {
+      this.setReportFields()
+      let date_start = Moment(this.fromTo.date_start).unix()
+      let date_end = Moment(this.fromTo.date_end).unix()
+      let agentGroupsIDs = this.agentGroups.map(obj => obj.id)
+      this.sessions = await this.$agent.p_mfa('ws_report', 'agent_activity_stats', [date_start, date_end, 'agent_id', 'agent_group_id', agentGroupsIDs])
+      // this.addMissingRows()
+    },
+    reset () {
+      this.sessions = []
+      this.agentGroups = []
+      this.fromTo = {
+        date_start: Moment().subtract(1, 'days').format(),
+        date_end: Moment().format()
+      }
+    },
+    setReportFields () {
+      this.reportFields.from = new Moment(this.fromTo.date_start).format('LL')
+      this.reportFields.to = new Moment(this.fromTo.date_end).format('LL')
+    },
+    findName (id) {
+      let obj = this.agents.find(v => { return v.id === id })
+      return obj.name
+    },
+    findLogin (id) {
+      let obj = this.agents.find(v => { return v.id === id })
+      return obj.login
+    },
+    addMissingRows () {
+      this.agents.forEach((obj) => {
+        if (this.sessions.find(v => { return v.id === obj.id}) === undefined) {
+          this.sessions.push({ id: obj.id })
+        }
+      })
+    },
+    durationFormatter (v) {
+      return Moment.duration(parseInt(v)).format("d[d] hh:*mm:ss", { forceLength: true })
+    },
+    getAgents: async function () {
+      this.agents = await this.$agent.p_mfa('ws_db_agent', 'suggest', [''])
+    }
+  },
+  created () {
+    this.getAgents()
   }
 }
 </script>
+

--- a/src/Report/Legacy/Agent/AgentAnswerPerformanceByGroup.vue
+++ b/src/Report/Legacy/Agent/AgentAnswerPerformanceByGroup.vue
@@ -2,6 +2,7 @@
   <report v-bind="reportFields" v-on:apply="query" v-on:reset="reset">
     <div slot="input-controls">
       <from-to v-model="fromTo"></from-to>
+      <entity-selector v-model="agentGroups" :query=agentGroupsQuery entity="Agent Groups"></entity-selector>
     </div>
     <div slot="report">
       <table>
@@ -23,13 +24,15 @@
 <script>
 import Report from '@/Report/Legacy/Report'
 import FromTo from '@/Report/Input/FromTo'
+import EntitySelector from '@/Report/Input/EntitySelector'
 import Moment from 'moment'
 
 export default {
   name: 'AgentAnswerPerformanceByGroup',
   components: {
     'report': Report,
-    'from-to': FromTo
+    'from-to': FromTo,
+    'entity-selector': EntitySelector,
   },
   data () {
     return {
@@ -38,19 +41,24 @@ export default {
           label: 'Name',
           tdClass: 'table-body-blue',
           thClass: 'table-header',
-          thStyle: { width: '120px' }
+          thStyle: { width: '120px' },
+          sortable: true,
+          formatter: v => this.findName(v)
         },
         login: {
           label: 'Login',
           tdClass: 'table-body-blue-last-in-group',
           thClass: 'table-header-last-in-group',
-          thStyle: { width: '67px' }
+          thStyle: { width: '67px' },
+          sortable: true,
+          formatter: (_v, _, item) => this.findLogin(item.agent_id)
         },
         ring_count: {
           label: 'Calls Offered',
           tdClass: ['table-body-green', 'text-align-right'],
           thClass: 'table-header',
           thStyle: { width: '80px' },
+          sortable: true,
           formatter: v => v ? v : 0
         },
         answered_count: {
@@ -58,6 +66,7 @@ export default {
           tdClass: ['table-body-green', 'text-align-right'],
           thClass: 'table-header',
           thStyle: { width: '80px' },
+          sortable: true,
           formatter: v => v ? v : 0
         },
         abandoned: {
@@ -65,6 +74,7 @@ export default {
           tdClass: ['table-body-green', 'text-align-right'],
           thClass: 'table-header',
           thStyle: { width: '80px' },
+          sortable: true,
           formatter: v => v ? v : 0
         },
         percent_answered: {
@@ -72,6 +82,7 @@ export default {
           tdClass: ['table-body-orange-last-in-group', 'text-align-right'],
           thClass: 'table-header-last-in-group',
           thStyle: { width: '84px' },
+          sortable: true,
           formatter: (v, _, item) => (item.ring_count != 0) ? (100 * item.answered_count / item.ring_count).toFixed(1) + '%' : 'NA'
         }
       },
@@ -79,25 +90,37 @@ export default {
         date_start: Moment().subtract(1, 'days').format(),
         date_end: Moment().format(),
       },
+      agentGroups: [],
+      agents: [],
       reportFields: {
         name: 'Agent Answer Performance by Group',
         title: 'Agent Answer Performance by Group',
         from: undefined,
         to: undefined
       },
-      sessions: []
+      sessions: [],
+      agentGroupsQuery: function () {
+        let profiles = this.$agent.p_mfa('ws_agent', 'agent_groups')
+        profiles.then ( p => p.push({ name: 'No Profile', id: -1 }))
+        return profiles
+      }
     }
   },
   methods: {
     query: async function () {
       this.setReportFields()
-      let qry = {}
-      qry.date_start = Moment(this.fromTo.date_start).unix()
-      qry.date_end = Moment(this.fromTo.date_end).unix()
-      this.sessions = await this.$agent.p_mfa('ws_report', 'agent_answer_performance', [qry.date_start, qry.date_end])
+      let date_start = Moment(this.fromTo.date_start).unix()
+      let date_end = Moment(this.fromTo.date_end).unix()
+      let agentGroupsIDs = this.agentGroups.map(obj => obj.id)
+      this.sessions = await this.$agent.p_mfa('ws_report', 'agent_answer_performance', [date_start, date_end, agentGroupsIDs])
+      
+      
+      //this.sessions = await this.$agent.p_mfa('ws_report', 'agent_answer_performance', [qry.date_start, qry.date_end])
     },
     reset () {
       this.sessions = []
+      this.agentGroups = []
+      this.getAgents()
       this.fromTo = {
         date_start: Moment().subtract(1, 'days').format(),
         date_end: Moment().format()
@@ -106,7 +129,21 @@ export default {
     setReportFields () {
       this.reportFields.from = new Moment(this.fromTo.date_start).format('LL')
       this.reportFields.to = new Moment(this.fromTo.date_end).format('LL')
+    },
+    findName (id) {
+      let obj = this.agents.find(v => { return v.id === id })
+      return obj.name
+    },
+    findLogin (id) {
+      let obj = this.agents.find(v => { return v.id === id })
+      return obj.login
+    },
+    getAgents: async function () {
+      this.agents = await this.$agent.p_mfa('ws_db_agent', 'suggest', [''])
     }
+  },
+  created () {
+    this.getAgents()
   }
 }
 </script>

--- a/src/Report/Legacy/Agent/AgentAnswerPerformanceByGroup.vue
+++ b/src/Report/Legacy/Agent/AgentAnswerPerformanceByGroup.vue
@@ -113,9 +113,6 @@ export default {
       let date_end = Moment(this.fromTo.date_end).unix()
       let agentGroupsIDs = this.agentGroups.map(obj => obj.id)
       this.sessions = await this.$agent.p_mfa('ws_report', 'agent_answer_performance', [date_start, date_end, agentGroupsIDs])
-      
-      
-      //this.sessions = await this.$agent.p_mfa('ws_report', 'agent_answer_performance', [qry.date_start, qry.date_end])
     },
     reset () {
       this.sessions = []

--- a/src/Report/Legacy/Agent/AgentCallDisposition.vue
+++ b/src/Report/Legacy/Agent/AgentCallDisposition.vue
@@ -50,7 +50,7 @@ export default {
       },
       dispColGroupWidth: undefined,
       sessions: [],
-      agentsQuery: function() {
+      agentsQuery: function () {
         return this.$agent.p_mfa('ws_agent', 'agents')
       }
     }
@@ -60,15 +60,15 @@ export default {
       this.setReportFields()
       let date_start = Moment(this.fromTo.date_start).unix()
       let date_end = Moment(this.fromTo.date_end).unix()
-      let agentIDs = this.agents.map(obj => obj.id)
-      
-      let data = await this.$agent.p_mfa('ws_report', 'agent_call_disposition', [date_start, date_end, agentIDs])
+      let agentsIDs = this.agents.map(obj => obj.id)
+      let data = await this.$agent.p_mfa('ws_report', 'agent_call_disposition', [date_start, date_end, agentsIDs])
       this.generateTableColumns(data)
       this.sessions = data
     },
     reset () {
       this.sessions = []
       this.fields = []
+      this.agents = []
       this.fromTo = {
         date_start: Moment().subtract(1, 'days').format(),
         date_end: Moment().format()
@@ -78,6 +78,18 @@ export default {
       this.reportFields.from = new Moment(this.fromTo.date_start).format('LL')
       this.reportFields.to = new Moment(this.fromTo.date_end).format('LL')
     },
+    findName (id) {
+      let obj = this.agents.find(v => { return v.id === id })
+      return obj.name
+    },
+    findLogin (id) {
+      let obj = this.agents.find(v => { return v.id === id })
+      return obj.login
+    },
+    findProfileName (id) {
+      let obj = this.agents.find(v => { return v.id === id })
+      return (obj.group.name !== undefined) ? obj.group.name : "No Profile"
+    },
     generateTableColumns (data) {
       this.fields = [
         {
@@ -85,21 +97,25 @@ export default {
           label: 'Name',
           tdClass: 'table-body-blue',
           thClass: 'table-header',
-          thStyle: { width: '120px' }
+          thStyle: { width: '120px' },
+          sortable: true,
+          formatter: v => this.findName(v)
         },
         {
           key: 'agent_group',
           label: 'Agent Group',
           tdClass: 'table-body-blue',
           thClass: 'table-header',
-          thStyle: { width: '120px' }
+          thStyle: { width: '120px' },
+          formatter: (_v, _, item) => this.findProfileName(item.agent_id)
         },
         {
           key: 'login',
           label: 'Login',
           tdClass: 'table-body-blue',
           thClass: 'table-header',
-          thStyle: { width: '70px' }
+          thStyle: { width: '70px' },
+          formatter: (_v, _, item) => this.findLogin(item.agent_id)
         },
         {
           key: 'calls',
@@ -107,6 +123,7 @@ export default {
           tdClass: ['table-body-blue-last-in-group', 'text-align-right'],
           thClass: 'table-header-last-in-group',
           thStyle: { width: '73px' },
+          sortable: true,
           formatter: v => v ? v : 0
         }
       ]

--- a/src/Report/Legacy/Agent/AgentGroupActivity.vue
+++ b/src/Report/Legacy/Agent/AgentGroupActivity.vue
@@ -1,14 +1,185 @@
 <template>
-  <div style="margin-top: 20px">
-    <strong>{{ title }}</strong> - To be added</div>
+  <report v-bind="reportFields" v-on:apply="query" v-on:reset="reset">
+    <div slot="input-controls">
+      <from-to v-model="fromTo"></from-to>
+      <entity-selector v-model="agentGroups" :query=agentGroupsQuery entity="Agent Groups"></entity-selector>
+    </div>
+    <div slot="report">
+      <table>
+        <tr>
+          <td class='table-sm table-header-group' style="width: 120px; max-width: 120px; min-width: 120px">
+            Agent Group
+          </td>
+          <td class='table-sm table-header-group' style="width: 319px; max-width: 319px; min-width: 319px">
+            Inbound Activity
+          </td>
+          <td class='table-sm table-header-group' style="width: 256px; max-width: 256px; min-width: 256px">
+            Outbound Activity
+          </td>
+          <td class='table-sm table-header-group' style="width: 128px; max-width: 128px; min-width: 128px">
+            Total Activity
+          </td>
+        </tr>
+      </table>
+      <b-table style="min-width: 6px; max-width: 6px; table-layout: fixed" small hover :items="sessions" :fields="fields">
+      </b-table>
+    </div>
+  </report>
 </template>
 
 <script>
+import Report from '@/Report/Legacy/Report'
+import FromTo from '@/Report/Input/FromTo'
+import EntitySelector from '@/Report/Input/EntitySelector'
+import Moment from 'moment'
+
 export default {
   name: 'AgentGroupActivity',
+  components: {
+    'report': Report,
+    'from-to': FromTo,
+    'entity-selector': EntitySelector
+  },
   data () {
     return {
-      title: 'Agent Group Activity'
+      fields: {
+        id: {
+          label: 'Name',
+          tdClass: 'table-body-blue-last-in-group',
+          thClass: 'table-header-last-in-group',
+          thStyle: { width: '120px' },
+          sortable: true,
+          formatter: v => this.findName(v)
+        },
+        in_answered: {
+          label: 'Total Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        in_talk_time: {
+          label: 'Total Time',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? this.durationFormatter(v) : this.durationFormatter(0)
+        },
+        in_completed: {
+          label: 'Completed Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        in_transferred: {
+          label: 'Transferred Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        in_avg_hold_time: {
+          label: 'Avg. Hold Time',
+          tdClass: ['table-body-green-last-in-group', 'text-align-right'],
+          thClass: 'table-header-last-in-group',
+          thStyle: { width: '67px' },
+          formatter: (v, _, item) => v ? this.durationFormatter(v) : 'NA'
+        },
+        out_started: {
+          label: 'Started Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        out_placed: {
+          label: 'Sent Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        out_answered: {
+          label: 'Answered Calls',
+          tdClass: ['table-body-green', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        out_talk_time: {
+          label: 'Total Time',
+          tdClass: ['table-body-green-last-in-group', 'text-align-right'],
+          thClass: 'table-header-last-in-group',
+          thStyle: { width: '67px' },
+          formatter: v => v ? this.durationFormatter(v) : this.durationFormatter(0)
+        },
+        total_calls: {
+          label: 'Total Calls',
+          tdClass: ['table-body-orange', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? v : 0
+        },
+        total_talk_time: {
+          label: 'Total Time',
+          tdClass: ['table-body-orange', 'text-align-right'],
+          thClass: 'table-header',
+          thStyle: { width: '63px' },
+          formatter: v => v ? this.durationFormatter(v) : this.durationFormatter(0)
+        }
+      },
+      fromTo: {
+        date_start: Moment().subtract(1, 'days').format(),
+        date_end: Moment().format(),
+      },
+      agentGroups: [],
+      reportFields: {
+        name: 'Agent Group Activity',
+        title: 'Agent Group Activity',
+        from: undefined,
+        to: undefined
+      },
+      sessions: [],
+      agentGroupsQuery: function () {
+        return this.$agent.p_mfa('ws_agent', 'agent_groups')
+      }
+    }
+  },
+  methods: {
+    query: async function () {
+      this.setReportFields()
+      let date_start = Moment(this.fromTo.date_start).unix()
+      let date_end = Moment(this.fromTo.date_end).unix()
+      let agentGroupsIDs = this.agentGroups.map(obj => obj.id)
+      this.sessions = await this.$agent.p_mfa('ws_report', 'agent_activity_stats', [date_start, date_end, 'agent_group_id', 'agent_group_id', agentGroupsIDs])
+      this.addMissingRows()
+    },
+    reset () {
+      this.sessions = []
+      this.agentGroups = []
+      this.fromTo = {
+        date_start: Moment().subtract(1, 'days').format(),
+        date_end: Moment().format()
+      }
+    },
+    setReportFields () {
+      this.reportFields.from = new Moment(this.fromTo.date_start).format('LL')
+      this.reportFields.to = new Moment(this.fromTo.date_end).format('LL')
+    },
+    findName (id) {
+      let obj = this.agentGroups.find(v => { return v.id === id })
+      return obj.name
+    },
+    addMissingRows () {
+      this.agentGroups.forEach((obj) => {
+        if (this.sessions.find(v => { return v.id === obj.id}) === undefined) {
+          this.sessions.push({ id: obj.id })
+        }
+      })
+    },
+    durationFormatter (v) {
+      return Moment.duration(parseInt(v)).format("d[d] hh:*mm:ss", { forceLength: true })
     }
   }
 }


### PR DESCRIPTION
+ ‘No Profile’ option for orphaned agents without Agent Group
+ typos in ACLs Entries.vue